### PR TITLE
Update README with local deployment instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,17 +32,15 @@ This project allows Web browser and API clients to easily generate JWT signing/v
 * For `HS*` keys, there is only private key (aka `secret`) and it is randomly generated using OpenSSL. 
 * All keys are expected to be generated on the backend using `OpenSSL` to increase security. 
 
-## Frontend 
-- Official Frontend URL: https://jwt-keys.21no.de/
-
 ## Backend API
-- Official URL: `https://jwt-keys.21no.de/api/generate/ALGORITHM?bytes=BYTES&bits=BITS`
+Run the service yourself (see [Run it using Docker](#run-it-using-docker) below) and call it locally:
+- URL pattern: `http://localhost:3000/api/generate/ALGORITHM?bytes=BYTES&bits=BITS`
 
 ### Examples:
-- Generate RS256 key pair: https://jwt-keys.21no.de/api/generate/RS256?bits=2048
-- Generate PS256 key pair: https://jwt-keys.21no.de/api/generate/PS256?bits=2048
-- Generate HS256 key pair: https://jwt-keys.21no.de/api/generate/HS256?bytes=32
-- Generate ES512 key pair: https://jwt-keys.21no.de/api/generate/ES512
+- Generate RS256 key pair: http://localhost:3000/api/generate/RS256?bits=2048
+- Generate PS256 key pair: http://localhost:3000/api/generate/PS256?bits=2048
+- Generate HS256 key pair: http://localhost:3000/api/generate/HS256?bytes=32
+- Generate ES512 key pair: http://localhost:3000/api/generate/ES512
 
 ### Parameters
 #### bytes (optional)


### PR DESCRIPTION
## Summary
Updated the README documentation to remove references to the official hosted service and provide guidance for self-hosting the application instead.

## Key Changes
- Removed the "Frontend" section that referenced the official frontend URL
- Updated the "Backend API" section to direct users to run the service locally using Docker
- Changed all API endpoint examples from the official domain (`https://jwt-keys.21no.de`) to localhost (`http://localhost:3000`)
- Updated the URL pattern documentation to reflect local deployment

## Details
This change shifts the documentation focus from a centrally-hosted service to a self-hosted deployment model. Users are now directed to run the service themselves locally rather than relying on the official public endpoints. This aligns with the security-conscious nature of the project, which emphasizes generating keys on the backend using OpenSSL.

https://claude.ai/code/session_01CZYsbPQ53FcTCXTztYkPgF